### PR TITLE
Update dokka to 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,6 +312,8 @@ configure([rootProject] + javaProjects) { project ->
 
 	pluginManager.withPlugin("kotlin") {
 		apply plugin: "org.jetbrains.dokka"
+		apply from: "${rootDir}/gradle/docs-dokka.gradle"
+
 		compileKotlin {
 			kotlinOptions {
 				languageVersion = "1.3"

--- a/gradle/docs-dokka.gradle
+++ b/gradle/docs-dokka.gradle
@@ -1,0 +1,30 @@
+tasks.findByName("dokkaHtmlPartial")?.configure {
+    outputDirectory.set(new File(buildDir, "docs/kdoc"))
+    dokkaSourceSets {
+        configureEach {
+            sourceRoots.setFrom(file("src/main/kotlin"))
+            classpath.from(sourceSets["main"].runtimeClasspath)
+            externalDocumentationLink {
+                url.set(new URL("https://docs.spring.io/spring-framework/docs/current/javadoc-api/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://projectreactor.io/docs/core/release/api/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://kotlin.github.io/kotlinx.coroutines/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("http://hamcrest.org/JavaHamcrest/javadoc/2.1/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://javadoc.io/doc/javax.servlet/javax.servlet-api/latest/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://javadoc.io/static/io.rsocket/rsocket-core/1.1.1/"))
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
 	repositories {
 		gradlePluginPortal()
-		maven { url 'https://repo.spring.io/plugins-release' }
+		maven { url "https://repo.spring.io/plugins-release" }
 	}
 }
 


### PR DESCRIPTION
Hi, i took some of the work that @sdeleuze did a while back and updated it with some external links to help you with migration to new gradle. 

Right now the dokka version in this is 1.5.0, which is the latest that is publicly released. This PR adds a configuration for dokka to run only over kotlin sources. This results in ok-ish generation times (about 2-3 minutes on my machine). If you want to have a complete docs (also for java sources) you can remove the `sourceRoots` option and probably search for some unresolved links to external libraries. 

Let me know what you think about new dokka ☺️ 